### PR TITLE
remove pyV8 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='UgliPyJS',
       package_data={
        	'uglipyjs': ['*.js'],
      },
-     requires=['PyV8','ordereddict','PyExecJS'],
+     requires=['ordereddict','PyExecJS'],
      license='MIT License',
      classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
UgliPyJS is not depend on pyV8 at all. it is optional dependency of PyExecJS.
PyExecJS can also work node. and since the PyV8 is not python3 ready it is better to remove concrete dependency on it.
